### PR TITLE
fix: ttl default was missing

### DIFF
--- a/token_config.go
+++ b/token_config.go
@@ -41,7 +41,7 @@ type TokenConfig struct {
 	PrivateKey KeyConfig `config:"privatekey"`
 	PublicKey  KeyConfig `config:"publickey"`
 	Shared     KeyConfig
-	TTL        time.Duration
+	TTL        time.Duration `config:"ttl,default=24h"`
 }
 
 // GetTTL returns the time-to-live for the token


### PR DESCRIPTION
Fixes the default token ttl setting

## Description
Sets the token ttl default value which was missed out when config was refactored.

## Related Issue
N/A

## Motivation and Context
Tokens were being issued already expired.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
